### PR TITLE
fix: prevent a potential buffer overflow

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,0 +1,21 @@
+name: Sanity checks
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: 
+      - ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          cargo install cbindgen
+      - name: Build
+        run: |
+          make build

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,8 +99,9 @@ pub extern "C" fn cureq_call(method: *const c_char, url: *const c_char, headers:
             break;
         }
         total_bytes_read += bytes_read;
-        if total_bytes_read >= max_ret_buffer as usize {
-            break;
+        if total_bytes_read > max_ret_buffer as usize {
+            // response is too large for ret_buffer
+            return -1;
         }
     };
 


### PR DESCRIPTION
When the total number of read octets is greater than the max return buffer size in bytes, we return a failure status (-1) instead of jumping out of the loop. Otherwise, a number larger than the maximum return buffer size might be returned upon success, which if unchecked by the caller, might cause a buffer overflow.

Note that the call to `reader.read(&mut ret_buffer[total_bytes_read..])` might return a value less than or equal to the available space in ret_buffer, which would make total_bytes_read no larger than the max return buffer size. However, we'd like to make the code safer by not depending on an assumption on the implementation of the `read` method.